### PR TITLE
 Enhanced Circuit Breaking Approach

### DIFF
--- a/scripts/aggregation_dump.py
+++ b/scripts/aggregation_dump.py
@@ -1,0 +1,57 @@
+from elasticsearch import Elasticsearch
+import random
+import time
+
+# Connect to Elasticsearch
+es = Elasticsearch(["http://localhost:9200"])  # Node-1 is running at :9200
+                                               # Node-2 is running at :9201
+
+# This is a script which basically fires only aggregation queries in order to increase the memory usage and this
+# will keep on running irrespective of the response
+
+heavy_agg_queries = [
+    {
+        "size": 0,
+        "aggs": {
+            "date_histogram_agg_with_big_arrays": {
+                "date_histogram": {
+                    "field": "timestamp",
+                    "calendar_interval": "1d"
+                },
+                "aggs": {
+                    "big_array_agg": {
+                        "scripted_metric": {
+                            "init_script": "state.big_array = new ArrayList();",
+                            "map_script": "state.big_array.add(doc['price'].value * doc['quantity'].value);",
+                            "combine_script": "double total = 0; for (t in state.big_array) { total += t } ",
+                            "reduce_script": "double total = 0; for (a in states) { if (a != null) { total += a } }"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+]
+
+# Function to execute random heavy aggregation queries infinitely
+def execute_random_heavy_agg_queries():
+    iteration = 1
+    while True:
+        try:
+            print(f"Iteration: {iteration}")
+            # Select a random query from heavy_agg_queries
+            random_query = random.choice(heavy_agg_queries)
+            result = es.search(index="my_index", body=random_query)
+            print(f"Query executed successfully")
+        except Exception as e:
+            error_message = str(e)
+            if "Data too large" in error_message:
+                print("A circuit Breaking Exception has trigerred")
+
+
+        iteration += 1
+        # Uncomment the following line to add a delay between iterations
+
+# Run the function to execute random heavy aggregation queries infinitely
+execute_random_heavy_agg_queries()

--- a/scripts/non_aggregation_dump.py
+++ b/scripts/non_aggregation_dump.py
@@ -1,0 +1,140 @@
+import random
+import time
+from elasticsearch import Elasticsearch
+
+# Connect to Elasticsearch
+es = Elasticsearch(["http://localhost:9200"])  # Change the URL as per your Elasticsearch configuration
+
+## A script which will fire Non Aggregation based queries of diffrent types and will STOP the moment it recieves a
+# CIRCUIT BREAKING EXCEPTION
+
+# 1. Search Query
+search_query = {
+    "query": {
+        "match_all": {}
+    }
+}
+
+# 2. Index Document
+index_doc = {
+    "title": "Sample Document",
+    "content": "This is a sample document for testing."
+}
+
+# 3. Get Document by ID
+get_doc_id = "1"
+
+# 4. Delete Document by ID
+delete_doc_id = "1"
+
+# 5. Update Document by ID
+update_doc = {
+    "doc": {
+        "title": "Updated Document",
+        "content": "This document has been updated."
+    }
+}
+
+# 6. Bulk API
+bulk_data = [
+    {"index": {"_index": "my_index", "_id": "1"}},
+    {"title": "Bulk Document 1", "content": "Bulk content 1"},
+    {"index": {"_index": "my_index", "_id": "2"}},
+    {"title": "Bulk Document 2", "content": "Bulk content 2"}
+]
+
+# 7. Term Query
+term_query = {
+    "query": {
+        "term": {
+            "title": "Sample"
+        }
+    }
+}
+
+# 8. Match Query
+match_query = {
+    "query": {
+        "match": {
+            "content": "test"
+        }
+    }
+}
+
+# 9. Multi Match Query
+multi_match_query = {
+    "query": {
+        "multi_match": {
+            "query": "Sample",
+            "fields": ["title", "content"]
+        }
+    }
+}
+
+# 10. Range Query
+range_query = {
+    "query": {
+        "range": {
+            "timestamp": {
+                "gte": "now-1d/d",
+                "lt": "now/d"
+            }
+        }
+    }
+}
+
+# 11. Transport Info Query
+transport_info_query = {}
+
+# List of all queries to randomize
+queries = [
+    ("search", search_query),
+    ("index", index_doc),
+    ("get", get_doc_id),
+    ("delete", delete_doc_id),
+    ("update", update_doc),
+    ("bulk", bulk_data),
+    ("term", term_query),
+    ("match", match_query),
+    ("multi_match", multi_match_query),
+    ("range", range_query),
+]
+
+def execute_random_query():
+    query_type, query = random.choice(queries)
+    try:
+        if query_type == "index":
+            es.index(index="my_index", body=query)
+            print("Index Document success")
+        elif query_type == "get":
+            es.get(index="my_index", id=query)
+            print("Get Document success")
+        elif query_type == "bulk":
+            es.bulk(body=query)
+            print("Bulk API success")
+        elif query_type == "term":
+            es.search(index="my_index", body=query)
+            print("Term Query success")
+        elif query_type == "match":
+            es.search(index="my_index", body=query)
+            print("Match Query success")
+        elif query_type == "multi_match":
+            es.search(index="my_index", body=query)
+            print("Multi Match Query success")
+        elif query_type == "range":
+            es.search(index="my_index", body=query)
+            print("Range Query success")
+    except Exception as e:
+        error_message = str(e)
+        print(f"{query_type.capitalize()} Query error: {error_message}")
+        if "Data too large" in error_message:
+            print("Stopping script due to 'Circuit Breaking Exception' error.")
+            return False
+    return True
+
+# Execute Queries in an Infinite Loop
+print("\nExecuting Search-based and Other Queries...")
+while True:
+    if not execute_random_query():
+        break
+    #time.sleep(1)  # Adding a delay to avoid overwhelming the server

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -296,7 +296,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         }
 
         synchronized long addEstimateAndMaybeBreak(long estimatedSize) {
-            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedSize, "<reduce_aggs>");
+            circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedSize, "[agg]<reduce_aggs>");
             circuitBreakerBytes += estimatedSize;
             maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);
             return circuitBreakerBytes;

--- a/server/src/main/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerService.java
@@ -33,7 +33,7 @@ public class PreallocatedCircuitBreakerService extends CircuitBreakerService imp
             throw new IllegalArgumentException("can't preallocate negative or zero bytes but got [" + bytesToPreallocate + "]");
         }
         CircuitBreaker nextBreaker = next.getBreaker(breakerToPreallocate);
-        nextBreaker.addEstimateBytesAndMaybeBreak(bytesToPreallocate, "preallocate[" + label + "]");
+        nextBreaker.addEstimateBytesAndMaybeBreak(bytesToPreallocate, "[agg]preallocate[" + label + "]");
         this.next = next;
         this.preallocated = new PreallocatedCircuitBreaker(nextBreaker, bytesToPreallocate);
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -321,6 +321,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_MAX_CLOSED_CHANNEL_COUNT,
                 HierarchyCircuitBreakerService.USE_REAL_MEMORY_USAGE_SETTING,
                 HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING,
+                HierarchyCircuitBreakerService.USE_MODIFIED_CIRCUIT_BREAKER_SETTING,
                 HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING,
                 HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_OVERHEAD_SETTING,
                 HierarchyCircuitBreakerService.IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -396,7 +396,7 @@ public class BigArrays {
                 // have to if the delta is negative
                 if (delta > 0) {
                     try {
-                        breaker.addEstimateBytesAndMaybeBreak(delta, "<reused_arrays>");
+                        breaker.addEstimateBytesAndMaybeBreak(delta, "[agg]<reused_arrays>");
                     } catch (CircuitBreakingException e) {
                         if (isDataAlreadyCreated) {
                             // since we've already created the data, we need to

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -139,7 +139,7 @@ public abstract class AggregatorBase extends Aggregator {
     protected long addRequestCircuitBreakerBytes(long bytes) {
         // Only use the potential to circuit break if bytes are being incremented
         if (bytes > 0) {
-            context.breaker().addEstimateBytesAndMaybeBreak(bytes, "<agg [" + name + "]>");
+            context.breaker().addEstimateBytesAndMaybeBreak(bytes, "[agg]<agg [" + name + "]>");
         } else {
             context.breaker().addWithoutBreaking(bytes);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -121,7 +121,7 @@ public class MultiBucketConsumerService {
             // check parent circuit breaker every 1024 calls
             callCount++;
             if ((callCount & 0x3FF) == 0) {
-                breaker.addEstimateBytesAndMaybeBreak(0, "allocated_buckets");
+                breaker.addEstimateBytesAndMaybeBreak(0, "[agg]allocated_buckets");
             }
         }
 


### PR DESCRIPTION
This PR implements a modified approach to circuit breaking in Elasticsearch. The goal is to enhance the parent circuit breaker mechanism by ensuring it only triggers during aggregation-based search queries. The changes involve identifying specific labels associated with aggregation requests and introducing a new cluster setting to control this modified behavior.

## Key Changes

### 1. Label Identification for Aggregation Requests
- **Labels with `[agg]` Prefix**: Certain labels that indicate aggregation-based queries have been prefixed with `[agg]`. This helps in identifying whether the circuit breaker should consider these labels when deciding to trip.
  - Modified labels include:
    - `<reduce_aggs>` to `[agg]<reduce_aggs>`
    - `preallocate[...]` to `[agg]preallocate[...]`
    - `<reused_arrays>` to `[agg]<reused_arrays>`
    - `<agg [name]>` to `[agg]<agg [name]>`
    - `allocated_buckets` to `[agg]allocated_buckets`

### 2. New Cluster Setting
- **Dynamic Cluster Setting**: A new boolean setting, `indices.breaker.total.use_modified_circuit_breaker`, has been introduced. This setting allows enabling or disabling the modified circuit breaking approach dynamically.
  - Default value: `false`
  - Setting is dynamic and scoped to the node.

### 3. Consumer Method for Setting Updates
- **Setting Update Consumer**: A method has been implemented to handle updates to the new cluster setting. This ensures that changes to the setting are applied in real-time without requiring a node restart.

### 4. HierarchyCircuitBreaker Check
- **Circuit Breaker Check**: In the `HierarchyCircuitBreakerService`, when checking if the circuit should be broken, the code now also checks the value of the new setting and the label prefix. The circuit will only break if the setting is enabled and the label has the `[agg]` prefix.

### Configuration

- **Enable Modified Circuit Breaker**
  ```yaml

  indices:
    breaker:
      total:
        use_modified_circuit_breaker: true
