### PR TITLE
Modified Partial Search Implemented

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -445,6 +445,9 @@ final class RequestConverters {
         if (searchRequest.allowPartialSearchResults() != null) {
             params.withAllowPartialResults(searchRequest.allowPartialSearchResults());
         }
+        if (searchRequest.allowModifiedPartialSearchResults() != null) {
+            params.withAllowModifiedPartialResults(searchRequest.allowModifiedPartialSearchResults());
+        }
         params.withBatchedReduceSize(searchRequest.getBatchedReduceSize());
         if (searchRequest.scroll() != null) {
             params.putParam("scroll", searchRequest.scroll().keepAlive());
@@ -943,6 +946,9 @@ final class RequestConverters {
 
         Params withAllowPartialResults(boolean allowPartialSearchResults) {
             return putParam("allow_partial_search_results", Boolean.toString(allowPartialSearchResults));
+        }
+        Params withAllowModifiedPartialResults(boolean allowModifiedPartialSearchResults) {
+            return putParam("allow_modified_partial_search_results", Boolean.toString(allowModifiedPartialSearchResults));
         }
 
         Params withRealtime(boolean realtime) {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/SubmitAsyncSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/SubmitAsyncSearchRequest.java
@@ -164,6 +164,11 @@ public class SubmitAsyncSearchRequest implements Validatable {
         this.searchRequest.allowPartialSearchResults(allowPartialSearchResults);
     }
 
+    public void setAllowModifiedSearchResults(boolean allowModifiedPartialSearchResults)
+    {
+        this.searchRequest.allowModifiedPartialSearchResults(allowModifiedPartialSearchResults);
+    }
+
     /**
      * Gets if this request should allow partial results.
      */

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
@@ -44,6 +44,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
     private final String[] types;
     private final Boolean requestCache;
     private final boolean allowPartialSearchResults;
+    private final boolean allowModifiedPartialSearchResults;
     private final Scroll scroll;
     private final int numberOfShards;
     private final long nowInMillis;
@@ -139,6 +140,8 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
         // at this stage. Any NPEs in the above are therefore an error in request preparation logic.
         assert searchRequest.allowPartialSearchResults() != null;
         this.allowPartialSearchResults = searchRequest.allowPartialSearchResults();
+        assert searchRequest.allowModifiedPartialSearchResults()!=null;
+        this.allowModifiedPartialSearchResults = searchRequest.allowModifiedPartialSearchResults();
         this.scroll = searchRequest.scroll();
         this.numberOfShards = numberOfShards;
         this.nowInMillis = nowInMillis;
@@ -156,6 +159,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
         scroll = in.readOptionalWriteable(Scroll::new);
         requestCache = in.readOptionalBoolean();
         allowPartialSearchResults = in.readBoolean();
+        allowModifiedPartialSearchResults = in.readBoolean();
         numberOfShards = in.readVInt();
         nowInMillis = in.readVLong();
         clusterAlias = in.readOptionalString();
@@ -174,6 +178,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
         out.writeOptionalWriteable(scroll);
         out.writeOptionalBoolean(requestCache);
         out.writeBoolean(allowPartialSearchResults);
+        out.writeBoolean(allowModifiedPartialSearchResults);
         out.writeVInt(numberOfShards);
         out.writeVLong(nowInMillis);
         out.writeOptionalString(clusterAlias);
@@ -202,6 +207,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
             r.aliasFilter,
             r.indexBoost,
             allowPartialSearchResults,
+            allowModifiedPartialSearchResults,
             scroll,
             nowInMillis,
             clusterAlias,

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -197,23 +197,27 @@ final class CanMatchPreFilterSearchPhase extends SearchPhase {
         assert assertSearchCoordinationThread();
         assert request.allowPartialSearchResults() != null : "SearchRequest missing setting for allowPartialSearchResults";
         if (request.allowPartialSearchResults() == false) {
-            final StringBuilder missingShards = new StringBuilder();
-            // Fail-fast verification of all shards being available
-            for (int index = 0; index < shardsIts.size(); index++) {
-                final SearchShardIterator shardRoutings = shardsIts.get(index);
-                if (shardRoutings.size() == 0) {
-                    if (missingShards.length() > 0) {
-                        missingShards.append(", ");
+            assert request.allowModifiedPartialSearchResults() != null : "SearchRequest missing setting for allowModifiedPartialSearchResults";
+            if(request.allowModifiedPartialSearchResults()==false) {
+                final StringBuilder missingShards = new StringBuilder();
+                // Fail-fast verification of all shards being available
+                for (int index = 0; index < shardsIts.size(); index++) {
+                    final SearchShardIterator shardRoutings = shardsIts.get(index);
+                    if (shardRoutings.size() == 0) {
+                        if (missingShards.length() > 0) {
+                            missingShards.append(", ");
+                        }
+                        missingShards.append(shardRoutings.shardId());
                     }
-                    missingShards.append(shardRoutings.shardId());
                 }
-            }
-            if (missingShards.length() > 0) {
-                // Status red - shard is missing all copies and would produce partial results for an index search
-                final String msg = "Search rejected due to missing shards ["
-                    + missingShards
-                    + "]. Consider using `allow_partial_search_results` setting to bypass this error.";
-                throw new SearchPhaseExecutionException(getName(), msg, null, ShardSearchFailure.EMPTY_ARRAY);
+                if (missingShards.length() > 0) {
+                    // Status red - shard is missing all copies and would produce partial results for an index search
+                    final String msg = "Search rejected due to missing shards ["
+                        + missingShards
+                        + "]. Consider using `allow_partial_search_results` setting to bypass this error.";
+                    throw new SearchPhaseExecutionException(getName(), msg, null, ShardSearchFailure.EMPTY_ARRAY);
+
+                }
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -281,7 +281,9 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
                             searchRequest.routing(nodeStringValue(value, null));
                         } else if ("allow_partial_search_results".equals(entry.getKey())) {
                             searchRequest.allowPartialSearchResults(nodeBooleanValue(value, null));
-                        } else if ("expand_wildcards".equals(entry.getKey()) || "expandWildcards".equals(entry.getKey())) {
+                        } else if ("allow_modified_partial_search_results".equals(entry.getKey())) {
+                            searchRequest.allowModifiedPartialSearchResults(nodeBooleanValue(value, null));
+                        }else if ("expand_wildcards".equals(entry.getKey()) || "expandWildcards".equals(entry.getKey())) {
                             expandWildcards = value;
                         } else if ("ignore_unavailable".equals(entry.getKey()) || "ignoreUnavailable".equals(entry.getKey())) {
                             ignoreUnavailable = value;
@@ -387,6 +389,9 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
         }
         if (request.allowPartialSearchResults() != null) {
             xContentBuilder.field("allow_partial_search_results", request.allowPartialSearchResults());
+        }
+        if(request.allowModifiedPartialSearchResults()!=null) {
+            xContentBuilder.field("allow_modified_partial_search_results", request.allowModifiedPartialSearchResults());
         }
         xContentBuilder.endObject();
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -81,6 +81,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
 
     private Boolean allowPartialSearchResults;
 
+    private Boolean allowModifiedPartialSearchResults;
+
     private Scroll scroll;
 
     private int batchedReduceSize = DEFAULT_BATCHED_REDUCE_SIZE;
@@ -199,6 +201,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         boolean finalReduce
     ) {
         this.allowPartialSearchResults = searchRequest.allowPartialSearchResults;
+        this.allowModifiedPartialSearchResults = searchRequest.allowModifiedPartialSearchResults;
         this.batchedReduceSize = searchRequest.batchedReduceSize;
         this.ccsMinimizeRoundtrips = searchRequest.ccsMinimizeRoundtrips;
         this.indices = indices;
@@ -247,6 +250,9 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         }
         if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
             allowPartialSearchResults = in.readOptionalBoolean();
+        }
+        if (in.getVersion().onOrAfter(Version.V_6_3_0)) {
+            allowModifiedPartialSearchResults = in.readOptionalBoolean();
         }
         if (in.getVersion().onOrAfter(Version.V_6_7_0)) {
             localClusterAlias = in.readOptionalString();
@@ -299,6 +305,9 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         }
         if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
             out.writeOptionalBoolean(allowPartialSearchResults);
+        }
+        if (out.getVersion().onOrAfter(Version.V_6_3_0)) {
+            out.writeOptionalBoolean(allowModifiedPartialSearchResults);
         }
         if (out.getVersion().onOrAfter(Version.V_6_7_0)) {
             out.writeOptionalString(localClusterAlias);
@@ -688,8 +697,17 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         return this;
     }
 
+    public SearchRequest allowModifiedPartialSearchResults(boolean allowModifiedPartialSearchResults) {
+        this.allowModifiedPartialSearchResults = allowModifiedPartialSearchResults;
+        return this;
+    }
+
     public Boolean allowPartialSearchResults() {
         return this.allowPartialSearchResults;
+    }
+
+    public Boolean allowModifiedPartialSearchResults() {
+        return this.allowModifiedPartialSearchResults;
     }
 
     /**
@@ -882,6 +900,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             && Objects.equals(preFilterShardSize, that.preFilterShardSize)
             && Objects.equals(indicesOptions, that.indicesOptions)
             && Objects.equals(allowPartialSearchResults, that.allowPartialSearchResults)
+            && Objects.equals(allowModifiedPartialSearchResults, that.allowModifiedPartialSearchResults)
             && Objects.equals(localClusterAlias, that.localClusterAlias)
             && absoluteStartMillis == that.absoluteStartMillis
             && ccsMinimizeRoundtrips == that.ccsMinimizeRoundtrips
@@ -905,6 +924,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             maxConcurrentShardRequests,
             preFilterShardSize,
             allowPartialSearchResults,
+            allowModifiedPartialSearchResults,
             localClusterAlias,
             absoluteStartMillis,
             ccsMinimizeRoundtrips,
@@ -942,6 +962,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             + preFilterShardSize
             + ", allowPartialSearchResults="
             + allowPartialSearchResults
+            + ", allowModifiedPartialSearchResults="
+            + allowModifiedPartialSearchResults
             + ", localClusterAlias="
             + localClusterAlias
             + ", getOrCreateAbsoluteStartMillis="

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -539,6 +539,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return this;
     }
 
+    public SearchRequestBuilder setAllowModifiedSearchResults(boolean allowModifiedPartialSearchResults) {
+        request.allowModifiedPartialSearchResults(allowModifiedPartialSearchResults);
+        return this;
+    }
+
     /**
      * Should the query be profiled. Defaults to <code>false</code>
      */

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -89,6 +89,8 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -113,6 +115,16 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         Property.NodeScope
     );
 
+
+    public static final Setting<String> MODIFIED_PARTIAL_SEARCH_RESULT_LIMIT = Setting.simpleString(
+        "action.search.modified_partial_search_result_limit",
+        "",
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
+
+
     public static final Setting<Integer> DEFAULT_PRE_FILTER_SHARD_SIZE = Setting.intSetting(
         "action.search.pre_filter_shard_size.default",
         SearchRequest.DEFAULT_PRE_FILTER_SHARD_SIZE,
@@ -131,6 +143,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     private final CircuitBreaker circuitBreaker;
     private final ExecutorSelector executorSelector;
     private final int defaultPreFilterShardSize;
+    private String previousPartialString="";
+    private long previousPartialAge=Long.MAX_VALUE;
 
     @Inject
     public TransportSearchAction(
@@ -911,6 +925,49 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         return indices;
     }
 
+    public static long parseDurationToMillis(String duration) {
+        long millis = 0;
+
+        // Define the regex pattern for matching each time component
+        String regex = "(?:(\\d+)yr)?(?:(\\d+)mo)?(?:(\\d+)da)?(?:(\\d+)hr)?(?:(\\d+)mi)?(?:(\\d+)se)?";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(duration);
+
+        // Constants for converting each time unit to milliseconds
+        long MILLIS_IN_SECOND = 1000;
+        long MILLIS_IN_MINUTE = 60 * MILLIS_IN_SECOND;
+        long MILLIS_IN_HOUR = 60 * MILLIS_IN_MINUTE;
+        long MILLIS_IN_DAY = 24 * MILLIS_IN_HOUR;
+        long MILLIS_IN_MONTH = 30 * MILLIS_IN_DAY;
+        long MILLIS_IN_YEAR = 365 * MILLIS_IN_DAY;
+
+        // Iterate over the matches and sum up the total duration in milliseconds
+        if (matcher.matches()) {
+            if (matcher.group(1) != null) {
+                millis += Long.parseLong(matcher.group(1)) * MILLIS_IN_YEAR;
+            }
+            if (matcher.group(2) != null) {
+                millis += Long.parseLong(matcher.group(2)) * MILLIS_IN_MONTH;
+            }
+            if (matcher.group(3) != null) {
+                millis += Long.parseLong(matcher.group(3)) * MILLIS_IN_DAY;
+            }
+            if (matcher.group(4) != null) {
+                millis += Long.parseLong(matcher.group(4)) * MILLIS_IN_HOUR;
+            }
+            if (matcher.group(5) != null) {
+                millis += Long.parseLong(matcher.group(5)) * MILLIS_IN_MINUTE;
+            }
+            if (matcher.group(6) != null) {
+                millis += Long.parseLong(matcher.group(6)) * MILLIS_IN_SECOND;
+            }
+        }
+        if(millis==0)
+            return Long.MAX_VALUE;
+
+        return millis;
+    }
+
     private void executeSearch(
         SearchTask task,
         SearchTimeProvider timeProvider,
@@ -1000,11 +1057,16 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         //here
         long currentTimeMillis = System.currentTimeMillis();
 
-        // Convert minutes to milliseconds (1 minute = 60 seconds * 1000 milliseconds/second)
-        long threeMinutesInMilliseconds = 3 * 60 * 1000;
 
-        // Subtract three minutes from current time to get time 3 minutes before
-        long timeBefore = currentTimeMillis - threeMinutesInMilliseconds;
+        String newSetting  = clusterService.getClusterSettings().get(MODIFIED_PARTIAL_SEARCH_RESULT_LIMIT);
+        if(newSetting.equals(previousPartialString)==false)
+        {
+            previousPartialString = newSetting;
+            previousPartialAge = parseDurationToMillis(previousPartialString);
+        }
+
+        long timeBefore = currentTimeMillis - previousPartialAge;
+        // Currently handling only one index
         if(clusterState.metadata().index(searchRequest.indices()[0])!=null) {
             if (clusterState.metadata().index(searchRequest.indices()[0]).getCreationDate() > timeBefore) {
                 searchRequest.allowModifiedPartialSearchResults(false);
@@ -1449,7 +1511,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         TimeValue keepAlive,
         boolean allowPartialSearchResults,
         boolean allowModifiedPartialSearchResults
-    
+
     ) {
         final List<SearchShardIterator> iterators = new ArrayList<>(searchContext.shards().size());
         for (Map.Entry<ShardId, SearchContextIdForNode> entry : searchContext.shards().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -339,6 +339,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchService.DEFAULT_ALLOW_MODIFIED_PARTIAL_SEARCH_RESULTS,
                 ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING,
                 TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
+                TransportSearchAction.MODIFIED_PARTIAL_SEARCH_RESULT_LIMIT,
                 TransportSearchAction.DEFAULT_PRE_FILTER_SHARD_SIZE,
                 RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE,
                 RemoteClusterService.SEARCH_REMOTE_CLUSTER_SKIP_UNAVAILABLE,

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -336,6 +336,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 MasterService.MASTER_SERVICE_STARVATION_LOGGING_THRESHOLD_SETTING,
                 SearchService.DEFAULT_SEARCH_TIMEOUT_SETTING,
                 SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS,
+                SearchService.DEFAULT_ALLOW_MODIFIED_PARTIAL_SEARCH_RESULTS,
                 ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING,
                 TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
                 TransportSearchAction.DEFAULT_PRE_FILTER_SHARD_SIZE,

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -152,6 +153,8 @@ public class RestSearchAction extends BaseRestHandler {
         IntConsumer setSize,
         BiConsumer<RestRequest, SearchRequest> extraParamParser
     ) throws IOException {
+
+
         if (searchRequest.source() == null) {
             searchRequest.source(new SearchSourceBuilder());
         }
@@ -186,6 +189,10 @@ public class RestSearchAction extends BaseRestHandler {
             searchRequest.allowPartialSearchResults(request.paramAsBoolean("allow_partial_search_results", null));
         }
 
+        if (request.hasParam("allow_modified_partial_search_results")) {
+            searchRequest.allowModifiedPartialSearchResults(request.paramAsBoolean("allow_modified_partial_search_results", null));
+        }
+
         searchRequest.searchType(request.param("search_type"));
         parseSearchSource(searchRequest.source(), request, setSize);
         searchRequest.requestCache(request.paramAsBoolean("request_cache", searchRequest.requestCache()));
@@ -212,7 +219,7 @@ public class RestSearchAction extends BaseRestHandler {
                 request.paramAsBoolean("ccs_minimize_roundtrips", searchRequest.isCcsMinimizeRoundtrips())
             );
         }
-
+        HeaderWarning.addWarning(searchRequest.buildDescription());
         extraParamParser.accept(request, searchRequest);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -197,6 +197,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope
     );
 
+    public static final Setting<Boolean> DEFAULT_ALLOW_MODIFIED_PARTIAL_SEARCH_RESULTS = Setting.boolSetting(
+        "search.default_allow_modified_partial_search_results",
+        true,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     public static final Setting<Integer> MAX_OPEN_SCROLL_CONTEXT = Setting.intSetting(
         "search.max_open_scroll_context",
         500,
@@ -249,6 +256,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private volatile TimeValue defaultSearchTimeout;
 
     private volatile boolean defaultAllowPartialSearchResults;
+
+    private volatile boolean defaultAllowModifiedPartialSearchResults;
 
     private volatile boolean lowLevelCancellation;
 
@@ -306,8 +315,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DEFAULT_SEARCH_TIMEOUT_SETTING, this::setDefaultSearchTimeout);
 
         defaultAllowPartialSearchResults = DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.get(settings);
+        defaultAllowModifiedPartialSearchResults = DEFAULT_ALLOW_MODIFIED_PARTIAL_SEARCH_RESULTS.get(settings);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS, this::setDefaultAllowPartialSearchResults);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(DEFAULT_ALLOW_MODIFIED_PARTIAL_SEARCH_RESULTS, this::setDefaultAllowModifiedPartialSearchResults);
+
 
         maxOpenScrollContext = MAX_OPEN_SCROLL_CONTEXT.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_OPEN_SCROLL_CONTEXT, this::setMaxOpenScrollContext);
@@ -352,8 +365,16 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         this.defaultAllowPartialSearchResults = defaultAllowPartialSearchResults;
     }
 
+    private void setDefaultAllowModifiedPartialSearchResults(boolean defaultAllowModifiedPartialSearchResults) {
+        this.defaultAllowModifiedPartialSearchResults = defaultAllowModifiedPartialSearchResults;
+    }
+
     public boolean defaultAllowPartialSearchResults() {
         return defaultAllowPartialSearchResults;
+    }
+
+    public boolean defaultAllowModifiedPartialSearchResults() {
+        return defaultAllowModifiedPartialSearchResults;
     }
 
     private void setMaxOpenScrollContext(int maxOpenScrollContext) {

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -257,7 +257,7 @@ public class QueryPhase {
             queryResult.terminatedEarly(true);
         } catch (TimeExceededException e) {
             assert timeoutSet : "TimeExceededException thrown even though timeout wasn't set";
-            if (searchContext.request().allowPartialSearchResults() == false) {
+            if (searchContext.request().allowPartialSearchResults() == false && searchContext.request().allowModifiedPartialSearchResults()==false) {
                 // Can't rethrow TimeExceededException because not serializable
                 throw new QueryPhaseExecutionException(searchContext.shardTarget(), "Time exceeded");
             }


### PR DESCRIPTION
This PR outlines the modifications made to the partial search approach, introducing a new setting that allows partial search based on the age of the indexes involved. The new setting determines whether partial search can be allowed based on the age of the indexes.

## Key Changes

### New Settings Introduced

1. **Default Allow Modified Partial Search Results**
   - **Type**: Boolean
   - **Setting**: `search.default_allow_modified_partial_search_results`
   - **Default Value**: `true`
   - **Description**: Allows partial search results by default.
   - **Properties**: Dynamic, NodeScope

2. **Modified Partial Search Result Limit**
   - **Type**: String
   - **Setting**: `action.search.modified_partial_search_result_limit`
   - **Default Value**: `""` (empty string)
   - **Description**: Specifies the age threshold for indexes to allow partial search. Format: `XyrXmoXdaXhrXmiXse` (years, months, days, hours, minutes, seconds)
   - **Properties**: Dynamic, NodeScope

### Logic for Partial Search

The partial search logic has been updated to incorporate the new settings as follows:

1. **Check Default Allow Modified Partial Search Results Setting**
   - If `true`, allow partial search.
   - If `false`, proceed to check the age of the indexes involved in the search request.

2. **Check Modified Partial Search Result Limit**
   - Parse the value of `action.search.modified_partial_search_result_limit` to determine the age threshold.
   - Compare the creation date of the indexes with the current date.
   - If the age exceeds the specified threshold, allow partial search.
   - If not, reject partial search.

### Configuration

- **Enable Age-Based Partial Search**
  ```yaml
  search:
    default_allow_modified_partial_search_results: true

  action:
    search:
      modified_partial_search_result_limit: "3yr2mo5da6hr7mi8se"
